### PR TITLE
Installed file is lowercase evio, not Evio

### DIFF
--- a/evio-5.1/cmake/evioConfig.cmake
+++ b/evio-5.1/cmake/evioConfig.cmake
@@ -1,1 +1,1 @@
-include("${CMAKE_CURRENT_LIST_DIR}/EvioTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/evioTargets.cmake")


### PR DESCRIPTION
Quick hotfix for minor bug in cmake for importing project as an external dep